### PR TITLE
Turn canMoveItem into a delegate call so implementors don't have to subclass

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -96,4 +96,9 @@ extension ViewController: PhotoCaptureViewControllerDelegate {
     func photoCaptureViewController(controller: PhotoCaptureViewController, deleteAssetAtIndexPath indexPath: NSIndexPath) {
         assets.removeAtIndex(indexPath.item)
         tableView.deleteRowsAtIndexPaths([NSIndexPath(forRow: 0, inSection: 0)], withRowAnimation: .Automatic)
-    }}
+    }
+
+    func photoCaptureViewController(controller: PhotoCaptureViewController, canMoveItemAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return true
+    }
+}

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -29,6 +29,7 @@ public protocol PhotoCaptureViewControllerDelegate: NSObjectProtocol {
     // eg photoCaptureViewControllerNumberOfAssets should be +1 after didAddAsset is called
     func photoCaptureViewController(controller: PhotoCaptureViewController, didAddAsset asset: Asset)
     func photoCaptureViewController(controller: PhotoCaptureViewController, deleteAssetAtIndexPath indexPath: NSIndexPath)
+    func photoCaptureViewController(controller: PhotoCaptureViewController, canMoveItemAtIndexPath indexPath: NSIndexPath) -> Bool
 }
 
 public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayoutDelegate {
@@ -43,15 +44,6 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
     private var containerView: UIView!
     private var focusIndicatorView: UIView!
     private var flashButton: UIButton!
-    
-    // MARK: - PhotoCollectionViewLayoutDelegate
-    public var photoCollectionViewLayoutShouldAllowCellMove:Bool
-        {
-        get {
-            // Add logic here to prevent moving of cells in specific situations
-            return true
-        }
-    }
 
     deinit {
         captureManager.stop(nil)
@@ -376,6 +368,12 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
 
             captureManager.lockFocusAtPointOfInterest(point)
         }
+    }
+
+    // MARK: - PhotoCollectionViewLayoutDelegate
+
+    public func photoCollectionViewLayout(layout: UICollectionViewLayout, canMoveItemAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return delegate?.photoCaptureViewController(self, canMoveItemAtIndexPath: indexPath) ?? true
     }
 
     // MARK: - Private methods


### PR DESCRIPTION
Have a public PhotoCaptureViewControllerDelegate delegate method that queries whether moving cells is currently allow when the longpress gesture is detected, instead of having it be a property you had to override in a subclass.

cc @AlexanderNorway 
