### PR TITLE
Image snapshotting problems iOS9

### DIFF
--- a/Finjinon/PhotoCollectionViewCell.swift
+++ b/Finjinon/PhotoCollectionViewCell.swift
@@ -28,6 +28,8 @@ public class PhotoCollectionViewCell: UICollectionViewCell {
         let offset = self.closeButton.bounds.height/3
         imageView.frame = CGRect(x: offset, y: offset, width: contentView.bounds.width - (offset*2), height: contentView.bounds.height - (offset*2))
         imageView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        imageView.contentMode = .ScaleAspectFill
+        imageView.clipsToBounds = true
         contentView.addSubview(imageView)
 
         closeButton.addTarget(self, action: Selector("closeButtonTapped:"), forControlEvents: .TouchUpInside)

--- a/Finjinon/PhotoCollectionViewCell.swift
+++ b/Finjinon/PhotoCollectionViewCell.swift
@@ -51,7 +51,13 @@ public class PhotoCollectionViewCell: UICollectionViewCell {
         delegate?.collectionViewCellDidTapDelete(self)
     }
 
-    public func imageViewProxy() -> UIImageView {
+    internal func proxy() -> UIView {
+        var wrapperFrame = self.imageView.bounds
+        wrapperFrame.origin.x = (bounds.size.width - wrapperFrame.size.width)/2
+        wrapperFrame.origin.y = (bounds.size.height - wrapperFrame.size.height)/2
+
+        let imageWrapper = UIView(frame: wrapperFrame)
+        imageWrapper.clipsToBounds = true
         let image = UIImage(CGImage: self.imageView.image!.CGImage!, scale: self.imageView.image!.scale, orientation: self.imageView.image!.imageOrientation)
 
         // Cumbersome indeed, but unfortunately re-rendering through begin graphicContext etc. fails quite often in iOS9
@@ -76,6 +82,8 @@ public class PhotoCollectionViewCell: UICollectionViewCell {
         imageView.clipsToBounds = true
         imageView.frame = imageRect
 
-        return imageView
+        imageWrapper.addSubview(imageView)
+
+        return imageWrapper
     }
 }

--- a/Finjinon/PhotoCollectionViewCell.swift
+++ b/Finjinon/PhotoCollectionViewCell.swift
@@ -50,4 +50,32 @@ public class PhotoCollectionViewCell: UICollectionViewCell {
     internal func closeButtonTapped(sender: UIButton) {
         delegate?.collectionViewCellDidTapDelete(self)
     }
+
+    public func imageViewProxy() -> UIImageView {
+        let image = UIImage(CGImage: self.imageView.image!.CGImage!, scale: self.imageView.image!.scale, orientation: self.imageView.image!.imageOrientation)
+
+        // Cumbersome indeed, but unfortunately re-rendering through begin graphicContext etc. fails quite often in iOS9
+        var imageRect : CGRect {
+            let viewSize = self.imageView.frame.size
+
+            let imageIsLandscape = image.size.width > image.size.height
+            if imageIsLandscape {
+                let ratio = image.size.height / viewSize.height
+                let width = image.size.width / ratio
+                let x = -(width - viewSize.width)/2
+                return CGRectMake(x, 0, width, viewSize.height)
+            } else {
+                let ratio = image.size.width / viewSize.width
+                let height = image.size.height / ratio
+                let y = -(height - viewSize.height)/2
+                return CGRectMake(0, y, viewSize.width, height)
+            }
+        }
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .ScaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.frame = imageRect
+
+        return imageView
+    }
 }

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -187,6 +187,7 @@ internal class PhotoCollectionViewLayout: UICollectionViewFlowLayout, UIGestureR
         case .Began:
             let location = recognizer.locationInView(collectionView)
             if let indexPath = collectionView!.indexPathForItemAtPoint(location), let cell = collectionView!.cellForItemAtIndexPath(indexPath) {
+                dragProxy?.removeFromSuperview()
                 let proxy = DraggingProxy(cell: cell)
                 proxy.dragIndexPath = indexPath
                 proxy.frame = cell.bounds

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -14,8 +14,6 @@ private class DraggingProxy: UIView {
     var fromIndexPath: NSIndexPath? // Original index path
     var toIndexPath: NSIndexPath? // index path the proxy was dragged to
     var initialCenter = CGPoint.zero
-//    private var proxyImageView : UIImageView
-//    private var imageWrapper : UIView
 
     init(cell: PhotoCollectionViewCell) {
         super.init(frame: CGRect.zero)
@@ -25,26 +23,6 @@ private class DraggingProxy: UIView {
         clipsToBounds = true
         frame = CGRect(x: 0, y: 0, width: cell.bounds.width, height: cell.bounds.height)
 
-        let image = UIImage(CGImage: cell.imageView.image!.CGImage!, scale: cell.imageView.image!.scale, orientation: cell.imageView.image!.imageOrientation)
-
-        // Cumbersome indeed, but unfortunately re-rendering through begin graphicContext etc. fails quite often in iOS9
-        var imageRect : CGRect {
-            let viewSize = cell.imageView.frame.size
-
-            let imageIsLandscape = image.size.width > image.size.height
-            if imageIsLandscape {
-                let ratio = image.size.height / viewSize.height
-                let width = image.size.width / ratio
-                let x = -(width - viewSize.width)/2
-                return CGRectMake(x, 0, width, viewSize.height)
-            } else {
-                let ratio = image.size.width / viewSize.width
-                let height = image.size.height / ratio
-                let y = -(height - viewSize.height)/2
-                return CGRectMake(0, y, viewSize.width, height)
-            }
-        }
-
         var wrapperFrame = cell.imageView.bounds
         wrapperFrame.origin.x = (cell.bounds.size.width - wrapperFrame.size.width)/2
         wrapperFrame.origin.y = (cell.bounds.size.height - wrapperFrame.size.height)/2
@@ -52,11 +30,7 @@ private class DraggingProxy: UIView {
         let imageWrapper = UIView(frame: wrapperFrame)
         imageWrapper.clipsToBounds = true
 
-        let proxyImageView = UIImageView(image: image)
-        proxyImageView.contentMode = .ScaleAspectFill
-        proxyImageView.clipsToBounds = true
-        proxyImageView.frame = imageRect
-
+        let proxyImageView = cell.imageViewProxy() //UIImageView(image: image)
         imageWrapper.addSubview(proxyImageView)
         addSubview(imageWrapper)
     }

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -8,23 +8,21 @@
 
 import UIKit
 
-private class DraggingProxy: UIImageView {
+private class DraggingProxy: UIView {
     var dragIndexPath: NSIndexPath? // Current indexPath
     var dragCenter = CGPoint.zero // point being dragged from
     var fromIndexPath: NSIndexPath? // Original index path
     var toIndexPath: NSIndexPath? // index path the proxy was dragged to
     var initialCenter = CGPoint.zero
+    private var imageView : UIImageView
 
-    init(cell: UICollectionViewCell) {
+    init(cell: PhotoCollectionViewCell) {
+        let image = cell.imageView.image
+        imageView = UIImageView(image: image)
         super.init(frame: CGRect.zero)
-        backgroundColor = UIColor.darkGrayColor() // fallback for iOS9 which sometimes winds up without an image
-
-        UIGraphicsBeginImageContextWithOptions(cell.bounds.size, false, 0)
-        cell.drawViewHierarchyInRect(cell.bounds, afterScreenUpdates: false) // false, because == true fails every single time on iOS9
-        let cellImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        image = cellImage
+        addSubview(imageView)
         frame = CGRect(x: 0, y: 0, width: cell.bounds.width, height: cell.bounds.height)
+        imageView.frame = cell.imageView.frame
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -189,7 +187,7 @@ internal class PhotoCollectionViewLayout: UICollectionViewFlowLayout, UIGestureR
             let location = recognizer.locationInView(collectionView)
             if let indexPath = collectionView!.indexPathForItemAtPoint(location), let cell = collectionView!.cellForItemAtIndexPath(indexPath) {
                 dragProxy?.removeFromSuperview()
-                let proxy = DraggingProxy(cell: cell)
+                let proxy = DraggingProxy(cell: cell as! PhotoCollectionViewCell)
                 proxy.dragIndexPath = indexPath
                 proxy.frame = cell.bounds
                 proxy.initialCenter = cell.center

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -23,16 +23,8 @@ private class DraggingProxy: UIView {
         clipsToBounds = true
         frame = CGRect(x: 0, y: 0, width: cell.bounds.width, height: cell.bounds.height)
 
-        var wrapperFrame = cell.imageView.bounds
-        wrapperFrame.origin.x = (cell.bounds.size.width - wrapperFrame.size.width)/2
-        wrapperFrame.origin.y = (cell.bounds.size.height - wrapperFrame.size.height)/2
-
-        let imageWrapper = UIView(frame: wrapperFrame)
-        imageWrapper.clipsToBounds = true
-
-        let proxyImageView = cell.imageViewProxy() //UIImageView(image: image)
-        imageWrapper.addSubview(proxyImageView)
-        addSubview(imageWrapper)
+        let proxyView = cell.proxy()
+        addSubview(proxyView)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -18,6 +18,8 @@ private class DraggingProxy: UIView {
     private var imageWrapper : UIView
 
     init(cell: PhotoCollectionViewCell) {
+        //TODO: Have another look at this, should be possible to simplify!
+
         let image = UIImage(CGImage: cell.imageView.image!.CGImage!, scale: cell.imageView.image!.scale, orientation: cell.imageView.image!.imageOrientation)
         print(cell.imageView)
 
@@ -29,20 +31,21 @@ private class DraggingProxy: UIView {
                 let ratio = imageSize.height / viewSize.height
                 let height = viewSize.height
                 let width = imageSize.width / ratio
-//                let x = (cell.bounds.width - width)/2
-//                let y = (cell.bounds.height - height)/2
-                return CGRectMake(0, 0, width, height)
+                let x = -(width - viewSize.width)/2
+                return CGRectMake(x, 0, width, height)
             } else {
                 let ratio = imageSize.width / viewSize.width
                 let width = viewSize.width
                 let height = imageSize.height / ratio
-//                let x = (cell.bounds.width - width)/2
-//                let y = (cell.bounds.height - height)/2
-                return CGRectMake(0, 0, width, height)
+                let y = -(height - viewSize.height)/2
+                return CGRectMake(0, y, width, height)
             }
         }
 
         proxyImageView = UIImageView(image: image)
+        proxyImageView.contentMode = .ScaleAspectFill
+        proxyImageView.clipsToBounds = true
+
         var wrapperFrame = cell.imageView.bounds
         wrapperFrame.origin.x = (cell.bounds.size.width - wrapperFrame.size.width)/2
         wrapperFrame.origin.y = (cell.bounds.size.height - wrapperFrame.size.height)/2

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -14,55 +14,51 @@ private class DraggingProxy: UIView {
     var fromIndexPath: NSIndexPath? // Original index path
     var toIndexPath: NSIndexPath? // index path the proxy was dragged to
     var initialCenter = CGPoint.zero
-    private var proxyImageView : UIImageView
-    private var imageWrapper : UIView
+//    private var proxyImageView : UIImageView
+//    private var imageWrapper : UIView
 
     init(cell: PhotoCollectionViewCell) {
-        //TODO: Have another look at this, should be possible to simplify!
+        super.init(frame: CGRect.zero)
+
+        backgroundColor = UIColor.clearColor()
+        autoresizingMask = cell.autoresizingMask
+        clipsToBounds = true
+        frame = CGRect(x: 0, y: 0, width: cell.bounds.width, height: cell.bounds.height)
 
         let image = UIImage(CGImage: cell.imageView.image!.CGImage!, scale: cell.imageView.image!.scale, orientation: cell.imageView.image!.imageOrientation)
-        print(cell.imageView)
 
         // Cumbersome indeed, but unfortunately re-rendering through begin graphicContext etc. fails quite often in iOS9
         var imageRect : CGRect {
-            let imageSize = image.size
             let viewSize = cell.imageView.frame.size
-            if imageSize.width > imageSize.height {
-                let ratio = imageSize.height / viewSize.height
-                let height = viewSize.height
-                let width = imageSize.width / ratio
+
+            let imageIsLandscape = image.size.width > image.size.height
+            if imageIsLandscape {
+                let ratio = image.size.height / viewSize.height
+                let width = image.size.width / ratio
                 let x = -(width - viewSize.width)/2
-                return CGRectMake(x, 0, width, height)
+                return CGRectMake(x, 0, width, viewSize.height)
             } else {
-                let ratio = imageSize.width / viewSize.width
-                let width = viewSize.width
-                let height = imageSize.height / ratio
+                let ratio = image.size.width / viewSize.width
+                let height = image.size.height / ratio
                 let y = -(height - viewSize.height)/2
-                return CGRectMake(0, y, width, height)
+                return CGRectMake(0, y, viewSize.width, height)
             }
         }
-
-        proxyImageView = UIImageView(image: image)
-        proxyImageView.contentMode = .ScaleAspectFill
-        proxyImageView.clipsToBounds = true
 
         var wrapperFrame = cell.imageView.bounds
         wrapperFrame.origin.x = (cell.bounds.size.width - wrapperFrame.size.width)/2
         wrapperFrame.origin.y = (cell.bounds.size.height - wrapperFrame.size.height)/2
 
-        imageWrapper = UIView(frame: wrapperFrame)
+        let imageWrapper = UIView(frame: wrapperFrame)
         imageWrapper.clipsToBounds = true
 
-        super.init(frame: CGRect.zero)
-        backgroundColor = UIColor.clearColor()
-
+        let proxyImageView = UIImageView(image: image)
+        proxyImageView.contentMode = .ScaleAspectFill
+        proxyImageView.clipsToBounds = true
         proxyImageView.frame = imageRect
-        autoresizingMask = cell.autoresizingMask
-        clipsToBounds = true
+
         imageWrapper.addSubview(proxyImageView)
-        imageWrapper.backgroundColor = UIColor.yellowColor()
         addSubview(imageWrapper)
-        frame = CGRect(x: 0, y: 0, width: cell.bounds.width, height: cell.bounds.height)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -229,7 +225,6 @@ internal class PhotoCollectionViewLayout: UICollectionViewFlowLayout, UIGestureR
                 dragProxy?.removeFromSuperview()
                 let proxy = DraggingProxy(cell: cell as! PhotoCollectionViewCell)
                 proxy.dragIndexPath = indexPath
-//                proxy.frame = cell.bounds
                 proxy.initialCenter = cell.center
                 proxy.dragCenter = cell.center
                 proxy.center = proxy.dragCenter

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -54,7 +54,7 @@ private class DraggingProxy: UIView {
         imageWrapper.clipsToBounds = true
 
         super.init(frame: CGRect.zero)
-        backgroundColor = UIColor.purpleColor()
+        backgroundColor = UIColor.clearColor()
 
         proxyImageView.frame = imageRect
         autoresizingMask = cell.autoresizingMask
@@ -242,7 +242,7 @@ internal class PhotoCollectionViewLayout: UICollectionViewFlowLayout, UIGestureR
                 invalidateLayout()
 
                 UIView.animateWithDuration(0.16, animations: {
-//                    self.dragProxy?.transform = CGAffineTransformMakeScale(1.1, 1.1)
+                    self.dragProxy?.transform = CGAffineTransformMakeScale(1.1, 1.1)
                 })
             }
         case .Ended:


### PR DESCRIPTION
This pull-request handles several different issues with the sorting of thumbnails in iOS9:

iOS9 has proven rather unreliable when it comes to snapshotting by using UIGraphicsBeginImageContext. As a result the proxy used to change the position of an image is not working properly. This aims to fix this by creating the proxy in a more cumbersome (bot working) manner.

Changes inherited from the ReorderingFrolicsomeness branch:
iOS9 manages to get double callbacks for some notifications which caused us to set up a double set of getsureRecognizers. This in turn made a double set of proxy's etc. making it very hard for the poor user to understand exactly what was going on.
