### PR TITLE
Rotate widgets

### DIFF
--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -88,6 +88,7 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
         flashButton.addTarget(self, action: Selector("flashButtonTapped:"), forControlEvents: .TouchUpInside)
         flashButton.titleLabel?.font = UIFont.preferredFontForTextStyle(UIFontTextStyleFootnote)
         flashButton.tintColor = UIColor.whiteColor()
+        flashButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
         roundifyButton(flashButton, inset: 14)
 
         let tapper = UITapGestureRecognizer(target: self, action: Selector("focusTapGestureRecognized:"))
@@ -142,6 +143,7 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
         closeButton.addTarget(self, action: Selector("doneButtonTapped:"), forControlEvents: .TouchUpInside)
         closeButton.setTitle(NSLocalizedString("Done", comment: ""), forState: .Normal)
         closeButton.tintColor = UIColor.whiteColor()
+        closeButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
         containerView.addSubview(closeButton)
 
         let pickerButtonWidth: CGFloat = 114
@@ -151,6 +153,7 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
         pickerButton.addTarget(self, action: Selector("presentImagePickerTapped:"), forControlEvents: .TouchUpInside)
         pickerButton.titleLabel?.font = UIFont.preferredFontForTextStyle(UIFontTextStyleFootnote)
         pickerButton.autoresizingMask = [.FlexibleTopMargin]
+        pickerButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
         roundifyButton(pickerButton)
         view.addSubview(pickerButton)
 
@@ -412,10 +415,6 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
     }
 
     private func updateWidgetsToOrientation() {
-        closeButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
-        flashButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
-        pickerButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
-
         var flashPosition = flashButton.frame.origin
         var pickerPosition = pickerButton.frame.origin
         if orientation == .LandscapeLeft || orientation == .LandscapeRight {

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -58,6 +58,7 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
     }
     private var pickerButton : UIButton!
     private var closeButton : UIButton!
+    private let buttonMargin : CGFloat = 12
 
     deinit {
         captureManager.stop(nil)
@@ -90,7 +91,7 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
         focusIndicatorView.alpha = 0.0
         previewView.addSubview(focusIndicatorView)
 
-        flashButton = UIButton(frame: CGRect(x: 12, y: 12, width: 70, height: 38))
+        flashButton = UIButton(frame: CGRect(x: buttonMargin, y: buttonMargin, width: 70, height: 38))
         flashButton.setImage(UIImage(named: "LightningIcon"), forState: .Normal)
         flashButton.setTitle(NSLocalizedString("Off", comment:"flash off"), forState: .Normal)
         flashButton.addTarget(self, action: Selector("flashButtonTapped:"), forControlEvents: .TouchUpInside)
@@ -153,7 +154,7 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
         containerView.addSubview(closeButton)
 
         let pickerButtonWidth: CGFloat = 114
-        pickerButton = UIButton(frame: CGRect(x: view.bounds.width - pickerButtonWidth - 12, y: 12, width: pickerButtonWidth, height: 38))
+        pickerButton = UIButton(frame: CGRect(x: view.bounds.width - pickerButtonWidth - buttonMargin, y: buttonMargin, width: pickerButtonWidth, height: 38))
         pickerButton.setTitle(NSLocalizedString("Photos", comment: "Select from Photos buttont itle"), forState: .Normal)
         pickerButton.setImage(UIImage(named: "PhotosIcon"), forState: .Normal)
         pickerButton.addTarget(self, action: Selector("presentImagePickerTapped:"), forControlEvents: .TouchUpInside)
@@ -414,27 +415,24 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
     }
 
     private func updateWidgetsToOrientation(orientation: UIInterfaceOrientation) {
-        print(orientation.rawValue)
         closeButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
         flashButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
         pickerButton.layer.anchorPoint = CGPointMake(0.5, 0.5)
 
-        var flashPosition = CGPointZero
-        var pickerPosition = CGPointZero
+        var flashPosition = CGPointMake(buttonMargin - (buttonMargin/3), buttonMargin)
+        var pickerPosition = CGPointMake(view.bounds.width - (pickerButton.bounds.size.width/2 - buttonMargin), buttonMargin)
+        if orientation == .Portrait || orientation == .PortraitUpsideDown {
+            pickerPosition = CGPointMake(view.bounds.width - (pickerButton.bounds.size.width + buttonMargin), buttonMargin)
+            flashPosition = CGPointMake(buttonMargin, buttonMargin)
+        }
 
         var radians : CGFloat {
             switch orientation {
             case .LandscapeLeft:
-                pickerPosition = CGPointMake(view.bounds.width - 45, 12) // 45 = width/2 - margin
-                flashPosition = CGPointMake(8, 12)
                 return CGFloat(-M_PI/2)
             case .LandscapeRight:
-                pickerPosition = CGPointMake(view.bounds.width - 45, 12) // 45 = width/2 - margin
-                flashPosition = CGPointMake(8, 12)
                 return CGFloat(M_PI/2)
             default:
-                pickerPosition = CGPointMake(view.bounds.width - 126, 12) // 126 = 114 + 12 (width + margin)?
-                flashPosition = CGPointMake(12, 12)
                 return 0
             }
         }

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -46,7 +46,6 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
     private var containerView: UIView!
     private var focusIndicatorView: UIView!
     private var flashButton: UIButton!
-//    private var widgetOrientation : UIInterfaceOrientation = .Portrait
     private var pickerButton : UIButton!
     private var closeButton : UIButton!
     private let buttonMargin : CGFloat = 12

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -447,6 +447,10 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
             self.flashButton.frame.origin = flashPosition
 
             self.closeButton.transform = rotation
+
+            for cell in self.collectionView.visibleCells() {
+                cell.transform = rotation
+            }
         }
         UIView.animateWithDuration(0.25, animations: animations)
         widgetOrientation = orientation
@@ -465,6 +469,14 @@ extension PhotoCaptureViewController: UICollectionViewDataSource, PhotoCollectio
             cell = delegateCell
         } else {
             cell = collectionView.dequeueReusableCellWithReuseIdentifier(PhotoCollectionViewCell.cellIdentifier(), forIndexPath: indexPath) as! PhotoCollectionViewCell
+        }
+
+        if widgetOrientation == .LandscapeLeft {
+            cell.transform = CGAffineTransformMakeRotation(CGFloat(-M_PI/2))
+        } else if widgetOrientation == .LandscapeRight {
+            cell.transform = CGAffineTransformMakeRotation(CGFloat(M_PI/2))
+        } else {
+            cell.transform = CGAffineTransformMakeRotation(0)
         }
 
         cell.delegate = self

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -47,15 +47,23 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
     private var focusIndicatorView: UIView!
     private var flashButton: UIButton!
     private var widgetOrientation : UIInterfaceOrientation = .Portrait
-    private var deviceOrientation : UIDeviceOrientation = UIDevice.currentDevice().orientation {
-        didSet {
-            let interfaceCompatibleOrientation = deviceOrientation != .FaceUp && deviceOrientation != .FaceDown && deviceOrientation != .Unknown
-            if interfaceCompatibleOrientation && widgetOrientation.rawValue != deviceOrientation.rawValue {
-                let newOrientation = UIInterfaceOrientation(rawValue: deviceOrientation.rawValue)!
-                updateWidgetsToOrientation(newOrientation)
-            }
-        }
-    }
+//    private var deviceOrientation : UIDeviceOrientation = UIDevice.currentDevice().orientation {
+//        didSet {
+//            switch deviceOrientation {
+//            case .FaceDown, .FaceUp, .Unknown:
+//                ()
+//            case .LandscapeLeft:
+//                widgetOrientation = .LandscapeLeft
+//            case .LandscapeRight:
+//                widgetOrientation = .LandscapeRight
+//            case .Portrait:
+//                widgetOrientation = .Portrait
+//            case .PortraitUpsideDown:
+//                widgetOrientation = .PortraitUpsideDown
+//            }
+//            updateWidgetsToOrientation(widgetOrientation)
+//        }
+//    }
     private var pickerButton : UIButton!
     private var closeButton : UIButton!
     private let buttonMargin : CGFloat = 12
@@ -181,7 +189,20 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
         }
 
         NSNotificationCenter.defaultCenter().addObserverForName(UIDeviceOrientationDidChangeNotification, object: nil, queue: nil) { (NSNotification) -> Void in
-            self.deviceOrientation = UIDevice.currentDevice().orientation
+            let deviceOrientation = UIDevice.currentDevice().orientation
+            switch deviceOrientation {
+            case .FaceDown, .FaceUp, .Unknown:
+                ()
+            case .LandscapeLeft:
+                self.widgetOrientation = .LandscapeLeft
+            case .LandscapeRight:
+                self.widgetOrientation = .LandscapeRight
+            case .Portrait:
+                self.widgetOrientation = .Portrait
+            case .PortraitUpsideDown:
+                self.widgetOrientation = .PortraitUpsideDown
+            }
+            self.updateWidgetsToOrientation(self.widgetOrientation)
         }
     }
 
@@ -429,9 +450,9 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
         var radians : CGFloat {
             switch orientation {
             case .LandscapeLeft:
-                return CGFloat(-M_PI/2)
-            case .LandscapeRight:
                 return CGFloat(M_PI/2)
+            case .LandscapeRight:
+                return CGFloat(-M_PI/2)
             default:
                 return 0
             }
@@ -447,11 +468,10 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
             self.closeButton.transform = rotation
 
             for cell in self.collectionView.visibleCells() {
-                cell.transform = rotation
+                cell.contentView.transform = rotation
             }
         }
         UIView.animateWithDuration(0.25, animations: animations)
-        widgetOrientation = orientation
     }
 }
 
@@ -470,11 +490,11 @@ extension PhotoCaptureViewController: UICollectionViewDataSource, PhotoCollectio
         }
 
         if widgetOrientation == .LandscapeLeft {
-            cell.transform = CGAffineTransformMakeRotation(CGFloat(-M_PI/2))
+            cell.contentView.transform = CGAffineTransformMakeRotation(CGFloat(M_PI/2))
         } else if widgetOrientation == .LandscapeRight {
-            cell.transform = CGAffineTransformMakeRotation(CGFloat(M_PI/2))
+            cell.contentView.transform = CGAffineTransformMakeRotation(CGFloat(-M_PI/2))
         } else {
-            cell.transform = CGAffineTransformMakeRotation(0)
+            cell.contentView.transform = CGAffineTransformMakeRotation(0)
         }
 
         cell.delegate = self

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -49,7 +49,7 @@ public class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLa
     private var widgetOrientation : UIInterfaceOrientation = .Portrait
     private var deviceOrientation : UIDeviceOrientation = UIDevice.currentDevice().orientation {
         didSet {
-            let interfaceCompatibleOrientation = deviceOrientation != .FaceUp || deviceOrientation != .FaceDown || deviceOrientation != .Unknown
+            let interfaceCompatibleOrientation = deviceOrientation != .FaceUp && deviceOrientation != .FaceDown && deviceOrientation != .Unknown
             if interfaceCompatibleOrientation && widgetOrientation.rawValue != deviceOrientation.rawValue {
                 let newOrientation = UIInterfaceOrientation(rawValue: deviceOrientation.rawValue)!
                 updateWidgetsToOrientation(newOrientation)

--- a/Finjinon/PhotoCollectionViewCell.swift
+++ b/Finjinon/PhotoCollectionViewCell.swift
@@ -81,6 +81,7 @@ public class PhotoCollectionViewCell: UICollectionViewCell {
         imageView.contentMode = .ScaleAspectFill
         imageView.clipsToBounds = true
         imageView.frame = imageRect
+        imageView.transform = transform
 
         imageWrapper.addSubview(imageView)
 

--- a/Finjinon/PhotoCollectionViewCell.swift
+++ b/Finjinon/PhotoCollectionViewCell.swift
@@ -81,9 +81,9 @@ public class PhotoCollectionViewCell: UICollectionViewCell {
         imageView.contentMode = .ScaleAspectFill
         imageView.clipsToBounds = true
         imageView.frame = imageRect
-        imageView.transform = transform
 
         imageWrapper.addSubview(imageView)
+        imageWrapper.transform = contentView.transform
 
         return imageWrapper
     }

--- a/FinjinonTests/FinjinonTests.swift
+++ b/FinjinonTests/FinjinonTests.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+import Finjinon
 
 class FinjinonTests: XCTestCase {
     
@@ -32,5 +33,57 @@ class FinjinonTests: XCTestCase {
             // Put the code you want to measure the time of here.
         }
     }
+
+    func testViewRotateToDeviceOrientationExtension() {
+        let view = UIView(frame: CGRect.zero)
+        view.rotateToDeviceOrientation(.Portrait)
+        let portraitTransform = view.transform
+        view.rotateToDeviceOrientation(.PortraitUpsideDown)
+        let portraitUpsideDownTransform = view.transform
+        view.rotateToDeviceOrientation(.LandscapeLeft)
+        let landscapeLeftTransform = view.transform
+        view.rotateToDeviceOrientation(.LandscapeRight)
+        let landscapRightTransform = view.transform
+
+        // portrait vs. portrait
+        XCTAssertEqual(portraitTransform.a, portraitUpsideDownTransform.a)
+        XCTAssertEqual(portraitTransform.b, portraitUpsideDownTransform.b)
+        XCTAssertEqual(portraitTransform.c, portraitUpsideDownTransform.c)
+
+        // portrait vs. landscape
+        XCTAssertNotEqual(portraitTransform.a, landscapeLeftTransform.a)
+        XCTAssertNotEqual(portraitTransform.b, landscapeLeftTransform.b)
+        XCTAssertNotEqual(portraitTransform.c, landscapeLeftTransform.c)
+        XCTAssertNotEqual(portraitUpsideDownTransform.a, landscapeLeftTransform.a)
+        XCTAssertNotEqual(portraitUpsideDownTransform.b, landscapeLeftTransform.b)
+        XCTAssertNotEqual(portraitUpsideDownTransform.c, landscapeLeftTransform.c)
+        XCTAssertNotEqual(portraitTransform.a, landscapRightTransform.a)
+        XCTAssertNotEqual(portraitTransform.b, landscapRightTransform.b)
+        XCTAssertNotEqual(portraitTransform.c, landscapRightTransform.c)
+        XCTAssertNotEqual(portraitUpsideDownTransform.a, landscapRightTransform.a)
+        XCTAssertNotEqual(portraitUpsideDownTransform.b, landscapRightTransform.b)
+        XCTAssertNotEqual(portraitUpsideDownTransform.c, landscapRightTransform.c)
+
+        // landscape vs. landscape
+        XCTAssertEqual(landscapRightTransform.a, landscapeLeftTransform.a)
+        XCTAssertNotEqual(landscapRightTransform.b, landscapeLeftTransform.b)
+        XCTAssertNotEqual(landscapRightTransform.c, landscapeLeftTransform.c)
+
+        // Test that .FaceUp & .FaceDown does not trigger any changes.
+        view.rotateToDeviceOrientation(.Portrait)
+        let unchangableTransform = view.transform
+        view.rotateToDeviceOrientation(.FaceDown)
+        let faceDownTransform = view.transform
+        view.rotateToDeviceOrientation(.FaceUp)
+        let faceUpTransform = view.transform
+        XCTAssertEqual(unchangableTransform.a, faceDownTransform.a)
+        XCTAssertEqual(unchangableTransform.b, faceDownTransform.b)
+        XCTAssertEqual(unchangableTransform.c, faceDownTransform.c)
+        XCTAssertEqual(unchangableTransform.a, faceUpTransform.a)
+        XCTAssertEqual(unchangableTransform.b, faceUpTransform.b)
+        XCTAssertEqual(unchangableTransform.c, faceUpTransform.c)
+    }
+
+
     
 }

--- a/FinjinonTests/FinjinonTests.swift
+++ b/FinjinonTests/FinjinonTests.swift
@@ -11,28 +11,6 @@ import XCTest
 import Finjinon
 
 class FinjinonTests: XCTestCase {
-    
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        XCTAssert(true, "Pass")
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock() {
-            // Put the code you want to measure the time of here.
-        }
-    }
 
     func testViewRotateToDeviceOrientationExtension() {
         let view = UIView(frame: CGRect.zero)
@@ -45,7 +23,7 @@ class FinjinonTests: XCTestCase {
         view.rotateToDeviceOrientation(.LandscapeRight)
         let landscapRightTransform = view.transform
 
-        // portrait vs. portrait
+        // portrait vs. portraitUpsideDown
         XCTAssertEqual(portraitTransform.a, portraitUpsideDownTransform.a)
         XCTAssertEqual(portraitTransform.b, portraitUpsideDownTransform.b)
         XCTAssertEqual(portraitTransform.c, portraitUpsideDownTransform.c)
@@ -64,7 +42,7 @@ class FinjinonTests: XCTestCase {
         XCTAssertNotEqual(portraitUpsideDownTransform.b, landscapRightTransform.b)
         XCTAssertNotEqual(portraitUpsideDownTransform.c, landscapRightTransform.c)
 
-        // landscape vs. landscape
+        // landscapeLeft vs. landscapeRight
         XCTAssertEqual(landscapRightTransform.a, landscapeLeftTransform.a)
         XCTAssertNotEqual(landscapRightTransform.b, landscapeLeftTransform.b)
         XCTAssertNotEqual(landscapRightTransform.c, landscapeLeftTransform.c)

--- a/FinjinonTests/FinjinonTests.swift
+++ b/FinjinonTests/FinjinonTests.swift
@@ -49,17 +49,17 @@ class FinjinonTests: XCTestCase {
 
         // Test that .FaceUp & .FaceDown does not trigger any changes.
         view.rotateToDeviceOrientation(.Portrait)
-        let unchangableTransform = view.transform
+        let unchangeableTransform = view.transform
         view.rotateToDeviceOrientation(.FaceDown)
         let faceDownTransform = view.transform
         view.rotateToDeviceOrientation(.FaceUp)
         let faceUpTransform = view.transform
-        XCTAssertEqual(unchangableTransform.a, faceDownTransform.a)
-        XCTAssertEqual(unchangableTransform.b, faceDownTransform.b)
-        XCTAssertEqual(unchangableTransform.c, faceDownTransform.c)
-        XCTAssertEqual(unchangableTransform.a, faceUpTransform.a)
-        XCTAssertEqual(unchangableTransform.b, faceUpTransform.b)
-        XCTAssertEqual(unchangableTransform.c, faceUpTransform.c)
+        XCTAssertEqual(unchangeableTransform.a, faceDownTransform.a)
+        XCTAssertEqual(unchangeableTransform.b, faceDownTransform.b)
+        XCTAssertEqual(unchangeableTransform.c, faceDownTransform.c)
+        XCTAssertEqual(unchangeableTransform.a, faceUpTransform.a)
+        XCTAssertEqual(unchangeableTransform.b, faceUpTransform.b)
+        XCTAssertEqual(unchangeableTransform.c, faceUpTransform.c)
     }
 
 


### PR DESCRIPTION
Wouldn't it be nice if the interface rotated when you rotate the device? 
Well, now it does.

Since we've locked the UIInterfaceOrientation we need to base this on listening to the UIDeviceOrientationDidChangeNotification and perform the appropriate transformation based on this.
![img_5250](https://cloud.githubusercontent.com/assets/1871987/10506417/09e4eadc-7318-11e5-9ab4-5a67105e9ad6.PNG)
