### PR TITLE
Allow network access for icloud photo library. Add custom activity indicator for uploads.

### DIFF
--- a/Finjinon/AssetResolver.swift
+++ b/Finjinon/AssetResolver.swift
@@ -25,6 +25,7 @@ internal struct AssetResolver {
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat
         options.resizeMode = .fast
+        options.isNetworkAccessAllowed = true
 
         let size = targetSize ?? defaultTargetSize
         manager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: options) { image, info in

--- a/Finjinon/Buttons.swift
+++ b/Finjinon/Buttons.swift
@@ -97,7 +97,7 @@ class CloseButton: UIButton {
         // Rotate path by 45° around its center
         let pathBounds = xPath.cgPath.boundingBox
         xPath.apply(CGAffineTransform(translationX: -pathBounds.midX, y: -pathBounds.midY))
-        xPath.apply(CGAffineTransform(rotationAngle: CGFloat(45.0 * M_PI / 180.0)))
+        xPath.apply(CGAffineTransform(rotationAngle: CGFloat(45.0 * Double.pi / 180.0)))
         xPath.apply(CGAffineTransform(translationX: pathBounds.midX, y: pathBounds.midY))
 
         xPath.lineWidth = 2

--- a/Finjinon/CaptureManager.swift
+++ b/Finjinon/CaptureManager.swift
@@ -112,7 +112,7 @@ class CaptureManager: NSObject {
                         print("failed creating metadata")
                     }
                 } else {
-                    NSLog("Failed capturing still imagE: \(error)")
+                    NSLog("Failed capturing still imagE: \(String(describing: error))")
                     // TODO
                 }
             })
@@ -179,7 +179,7 @@ class CaptureManager: NSObject {
                 try self.cameraDevice.lockForConfiguration()
             } catch let error1 as NSError {
                 error = error1
-                NSLog("Failed to lock camera device for configuration: \(error)")
+                NSLog("Failed to lock camera device for configuration: \(String(describing: error))")
             } catch {
                 fatalError()
             }

--- a/Finjinon/ImagePickerAdapter.swift
+++ b/Finjinon/ImagePickerAdapter.swift
@@ -47,7 +47,7 @@ open class ImagePickerControllerAdapter: NSObject, ImagePickerAdapter, UIImagePi
             selectionHandler([asset])
             completionHandler(false)
         } else {
-            NSLog("*** Failed to fetch PHAsset for asset library URL: \(referenceURL): \(fetchResult.firstObject)")
+            NSLog("*** Failed to fetch PHAsset for asset library URL: \(referenceURL): \(String(describing: fetchResult.firstObject))")
             completionHandler(true)
         }
     }

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -339,7 +339,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
                         self.didAddAsset(asset)
                         
                         count -= 1
-                        if count == 0{
+                        if count == 0 {
                             self.imagePickerWaitingForImageDataView?.removeFromSuperview()
                         }
                     })

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -325,6 +325,8 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         
         let controller = imagePickerAdapter.viewControllerForImageSelection({ assets in
             if let waitView = self.imagePickerWaitingForImageDataView, assets.count > 0 {
+                waitView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                waitView.frame = self.view.bounds
                 waitView.center = self.view.center
                 self.view.addSubview(waitView)
             }

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -324,9 +324,9 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         }
         
         let controller = imagePickerAdapter.viewControllerForImageSelection({ assets in
-            if self.imagePickerWaitingForImageDataView != nil && assets.count > 0 {
-                self.imagePickerWaitingForImageDataView!.center = self.view.center
-                self.view.addSubview(self.imagePickerWaitingForImageDataView!)
+            if let waitView = self.imagePickerWaitingForImageDataView, assets.count > 0 {
+                waitView.center = self.view.center
+                self.view.addSubview(waitView)
             }
             
             let resolver = AssetResolver()

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -321,29 +321,23 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
             return
         }
         
-        var asyncCompletionFinalCount = 0
-        var asyncCompletionCount = 0
-        func asyncCompletionCheck(count:Int, ofTotal total:Int) {
-            if count == total {
-                self.imagePickerProgressIndicatorView?.removeFromSuperview()
-            }
-        }
-        
         let controller = imagePickerAdapter.viewControllerForImageSelection({ assets in
-            if self.imagePickerProgressIndicatorView != nil {
+            if self.imagePickerProgressIndicatorView != nil && assets.count > 0 {
                 self.imagePickerProgressIndicatorView!.center = self.view.center 
                 self.view.addSubview(self.imagePickerProgressIndicatorView!)
             }
             
             let resolver = AssetResolver()
-            asyncCompletionFinalCount = assets.count
+            var count = assets.count
             assets.forEach { asset in
                 resolver.enqueueResolve(asset, completion: { image in
                     self.createAssetFromImage(image, completion: { (asset: Asset) in
                         self.didAddAsset(asset)
                         
-                        asyncCompletionCount += 1
-                        asyncCompletionCheck(count: asyncCompletionCount, ofTotal: asyncCompletionFinalCount)
+                        count -= 1
+                        if count == 0{
+                            self.imagePickerProgressIndicatorView?.removeFromSuperview()
+                        }
                     })
                 })
             }

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -503,9 +503,9 @@ extension UIView {
         case .faceDown, .faceUp, .unknown:
             ()
         case .landscapeLeft:
-            self.transform = CGAffineTransform(rotationAngle: CGFloat(M_PI/2))
+            self.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi/2))
         case .landscapeRight:
-            self.transform = CGAffineTransform(rotationAngle: CGFloat(-M_PI/2))
+            self.transform = CGAffineTransform(rotationAngle: CGFloat(-Double.pi/2))
         case .portrait, .portraitUpsideDown:
             self.transform = CGAffineTransform(rotationAngle: 0)
         }

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -36,7 +36,9 @@ public protocol PhotoCaptureViewControllerDelegate: NSObjectProtocol {
 open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayoutDelegate {
     open weak var delegate: PhotoCaptureViewControllerDelegate?
     open var imagePickerAdapter: ImagePickerAdapter = ImagePickerControllerAdapter()
-    open var imagePickerProgressIndicatorView: UIView?
+    
+    /// optional view to display when returning from imagePicker not finished retrieving data
+    open var imagePickerWaitingForImageDataView: UIView?
 
     fileprivate let storage = PhotoStorage()
     fileprivate let captureManager = CaptureManager()
@@ -322,9 +324,9 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         }
         
         let controller = imagePickerAdapter.viewControllerForImageSelection({ assets in
-            if self.imagePickerProgressIndicatorView != nil && assets.count > 0 {
-                self.imagePickerProgressIndicatorView!.center = self.view.center 
-                self.view.addSubview(self.imagePickerProgressIndicatorView!)
+            if self.imagePickerWaitingForImageDataView != nil && assets.count > 0 {
+                self.imagePickerWaitingForImageDataView!.center = self.view.center
+                self.view.addSubview(self.imagePickerWaitingForImageDataView!)
             }
             
             let resolver = AssetResolver()
@@ -336,7 +338,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
                         
                         count -= 1
                         if count == 0{
-                            self.imagePickerProgressIndicatorView?.removeFromSuperview()
+                            self.imagePickerWaitingForImageDataView?.removeFromSuperview()
                         }
                     })
                 })

--- a/Finjinon/PhotoStorage.swift
+++ b/Finjinon/PhotoStorage.swift
@@ -82,7 +82,7 @@ open class PhotoStorage {
                 try fileManager.removeItem(at: baseURL)
             } catch let error1 as NSError {
                 error = error1
-                NSLog("PhotoDiskCache: failed to cleanup cache dir at \(baseURL): \(error)")
+                NSLog("PhotoDiskCache: failed to cleanup cache dir at \(baseURL): \(String(describing: error))")
             }
         }
     }
@@ -98,7 +98,7 @@ open class PhotoStorage {
                 try data.write(to: URL(fileURLWithPath: cacheURL.path), options: .atomic)
             } catch let error1 as NSError {
                 error = error1
-                NSLog("Failed to write image to \(cacheURL): \(error)")
+                NSLog("Failed to write image to \(cacheURL): \(String(describing: error))")
                 // TODO: throw
             } catch {
                 fatalError()
@@ -136,7 +136,7 @@ open class PhotoStorage {
                 var error: NSError?
                 let bytesWritten = representation.getBytes(buffer, fromOffset: 0, length: bufferLength, error: &error)
                 if bytesWritten != bufferLength {
-                    NSLog("failed to get all bytes (wrote \(bytesWritten)/\(bufferLength)): \(error)")
+                    NSLog("failed to get all bytes (wrote \(bytesWritten)/\(bufferLength)): \(String(describing: error))")
                 }
                 self.createAssetFromImageData(data as Data, completion: completion)
             }
@@ -157,11 +157,11 @@ open class PhotoStorage {
                         })
                     }
                     }, failureBlock: { error in
-                        NSLog("failed to retrive ALAsset in 8.1 workaround: \(error)")
+                        NSLog("failed to retrive ALAsset in 8.1 workaround: \(String(describing: error))")
                 })
             }
             }, failureBlock: { error in
-                NSLog("failed to retrive ALAsset: \(error)")
+                NSLog("failed to retrive ALAsset: \(String(describing: error))")
         })
     }
 
@@ -173,7 +173,7 @@ open class PhotoStorage {
                 try self.fileManager.removeItem(atPath: cacheURL.path)
             } catch let error1 as NSError {
                 error = error1
-                NSLog("failed failed to remove asset at \(cacheURL): \(error)")
+                NSLog("failed failed to remove asset at \(cacheURL): \(String(describing: error))")
             } catch {
                 fatalError()
             }
@@ -240,7 +240,7 @@ open class PhotoStorage {
                 try fileManager.createDirectory(at: self.baseURL, withIntermediateDirectories: true, attributes: nil)
             } catch let error1 as NSError {
                 error = error1
-                NSLog("Failed to create cache directory at \(baseURL): \(error)")
+                NSLog("Failed to create cache directory at \(baseURL): \(String(describing: error))")
             }
         }
     }


### PR DESCRIPTION
### What?

`AssetResolver` has been updated with `PHImageRequestOptions().isNetworkAccessAllowed = true` to allow network access when retrieving full quality photos from iCloud Photo Library. 

`PhotoCaptureViewController` has got a new `imagePickerWaitingForImageDataView: UIView?` property which (if it isn't nil) is overlaid by `presentImagePickerTapped`; to serve a custom view containing for example an activity indicator. 

Tip: The custom view could also contain e.g. a button with code to reference back to `PhotoCaptureViewController`.imagePickerWaitingForImageDataView?.removeFromSuperview() to allow the user to hide it while upload continues in the background.

### Why?

Users experienced that some photos didn't get uploaded when selected, without any error or explanation given. This was probable due to a missing network-access permission in relation to iCloud Photo Library.