### PR TITLE
Image data source type for tracking

### DIFF
--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -333,7 +333,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
                     return constraint.secondItem as! UIView == self.view
                 }))
                 self.view.addConstraint(NSLayoutConstraint(item: waitView, attribute: .centerX, relatedBy: .equal, toItem: self.view, attribute: .centerX, multiplier: 1, constant: 0))
-                self.view.addConstraint(NSLayoutConstraint(item: waitView, attribute: .centerY, relatedBy: .equal, toItem: self.view, attribute: NSLayoutAttribute.centerY, multiplier: 1, constant: 0))
+                self.view.addConstraint(NSLayoutConstraint(item: waitView, attribute: .centerY, relatedBy: .equal, toItem: self.view, attribute: .centerY, multiplier: 1, constant: 0))
                 
                 switch UIDevice.current.orientation {
                 case .landscapeRight:

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -356,7 +356,9 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
             assets.forEach { asset in
                 resolver.enqueueResolve(asset, completion: { image in
                     self.createAssetFromImage(image, completion: { (asset: Asset) in
-                        self.didAddAsset(asset)
+                        var mutableAsset = asset
+                        mutableAsset.imageDataSourceType = .library
+                        self.didAddAsset(mutableAsset)
                         
                         count -= 1
                         if count == 0 {
@@ -383,7 +385,11 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         captureManager.captureImage { (data, metadata) in
             sender.isEnabled = true
 
-            self.createAssetFromImageData(data as Data, completion: self.didAddAsset)
+            self.createAssetFromImageData(data as Data, completion: { ( asset: Asset) in
+                var mutableAsset = asset
+                mutableAsset.imageDataSourceType = .camera
+                self.didAddAsset(asset)
+            })
         }
     }
 

--- a/Finjinon/PhotoStorage.swift
+++ b/Finjinon/PhotoStorage.swift
@@ -10,6 +10,10 @@ import UIKit
 import ImageIO
 import AssetsLibrary
 
+public enum AssetImageDataSourceTypes {
+    case camera, library, unknown
+}
+
 // TODO also support ALAsset/PHPhoto
 
 public struct Asset: Equatable, CustomStringConvertible {
@@ -49,6 +53,8 @@ public struct Asset: Equatable, CustomStringConvertible {
             return storage.dimensionsforAsset(self)
         }
     }
+    
+    public var imageDataSourceType: AssetImageDataSourceTypes = .unknown
 
     public var description: String {
         return "<\(type(of: self)) UUID: \(UUID)>"


### PR DESCRIPTION
### What?

A new `enum AssetImageDataSourceTypes` contains .camera, .library and .unknown, and is used with the `public var imageDataSourceType` property on the `Asset` class. The value is set when `PhotoCaptureViewController` either takes a new photo or selects image(s) from the library. Default is .unknown.

### Why?

There's a need to know the source for the image(s), e.g. for tracking camera-usage vs. library.
