### PR TITLE
Minor bugfix on parameter-value for didAddAsset in capturePhotoTapped().

### DIFF
--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -388,7 +388,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
             self.createAssetFromImageData(data as Data, completion: { ( asset: Asset) in
                 var mutableAsset = asset
                 mutableAsset.imageDataSourceType = .camera
-                self.didAddAsset(asset)
+                self.didAddAsset(mutableAsset)
             })
         }
     }


### PR DESCRIPTION
### What?

Parameter value for `didAddAsset` in `capturePhotoTapped()` now returns the mutated asset struct with added tracking info (and not the original asset).

### Why?

Using the camera returned .unknown as source.