### PR TITLE
Clean up non-attended TODOs

### DIFF
--- a/Finjinon/CaptureManager.swift
+++ b/Finjinon/CaptureManager.swift
@@ -93,7 +93,7 @@ class CaptureManager: NSObject {
         }
     }
 
-    func captureImage(_ completion: @escaping (Data, NSDictionary) -> Void) { // TODO: throws
+    func captureImage(_ completion: @escaping (Data, NSDictionary) -> Void) {
         captureQueue.async {
             guard let connection = self.stillImageOutput?.connection(withMediaType: AVMediaTypeVideo) else {
                 return
@@ -112,8 +112,7 @@ class CaptureManager: NSObject {
                         }
                     }
                 } else {
-                    NSLog("Failed capturing still imagE: \(String(describing: error))")
-                    // TODO:
+                    NSLog("Failed capturing still images: \(String(describing: error))")
                 }
             })
         }
@@ -202,7 +201,6 @@ class CaptureManager: NSObject {
                 if self.session.canAddInput(input) {
                     self.session.addInput(input)
                 } else {
-                    // TODO: handle?
                     NSLog("failed to add input \(input) to session \(self.session)")
                 }
             } catch let error1 as NSError {

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -59,8 +59,6 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
 
         view.backgroundColor = UIColor.black
 
-        // TODO: Move all the boring view setup to a storyboard/xib
-
         previewView = UIView(frame: view.bounds)
         previewView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(previewView)

--- a/Finjinon/PhotoCollectionViewLayout.swift
+++ b/Finjinon/PhotoCollectionViewLayout.swift
@@ -232,8 +232,6 @@ internal class PhotoCollectionViewLayout: UICollectionViewFlowLayout, UIGestureR
         case .changed:
             if let proxy = dragProxy {
                 proxy.center.x = proxy.initialCenter.x + translation.x
-                // TODO: Constrain to be within collectionView.frame:
-                // proxy.center.y = proxy.originalCenter.y + translation.y
 
                 if let fromIndexPath = proxy.dragIndexPath,
                     let toIndexPath = collectionView!.indexPathForItem(at: proxy.center),

--- a/Finjinon/PhotoStorage.swift
+++ b/Finjinon/PhotoStorage.swift
@@ -10,8 +10,6 @@ public enum AssetImageDataSourceTypes {
     case camera, library, unknown
 }
 
-// TODO: also support ALAsset/PHPhoto
-
 public struct Asset: Equatable, CustomStringConvertible {
     public let UUID = Foundation.UUID().uuidString
     let storage: PhotoStorage
@@ -101,7 +99,6 @@ open class PhotoStorage {
             } catch let error1 as NSError {
                 error = error1
                 NSLog("Failed to write image to \(cacheURL): \(String(describing: error))")
-                // TODO: throw
             } catch {
                 fatalError()
             }
@@ -226,7 +223,7 @@ open class PhotoStorage {
                         completion(thumbnailImage)
                     }
                 }
-            } // TODO: else throws
+            }
         }
     }
 


### PR DESCRIPTION
The reasoning is that TODOs that haven't been resolved for almost 2 years are most likely not going to be resolved anytime soon. 