### PR TITLE
Support for camera-only use

### DIFF
--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -31,7 +31,7 @@ public protocol PhotoCaptureViewControllerDelegate: NSObjectProtocol {
 
 open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayoutDelegate {
     open weak var delegate: PhotoCaptureViewControllerDelegate?
-    open var imagePickerAdapter: ImagePickerAdapter = ImagePickerControllerAdapter()
+    open var imagePickerAdapter: ImagePickerAdapter? = ImagePickerControllerAdapter()
 
     /// Optional view to display when returning from imagePicker not finished retrieving data.
     /// Use constraints to position elements dynamically, as the view will be rotated and sized with the device.
@@ -143,16 +143,18 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         closeButton.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
         containerView.addSubview(closeButton)
 
-        let pickerButtonWidth: CGFloat = 114
-        pickerButton = UIButton(frame: CGRect(x: view.bounds.width - pickerButtonWidth - buttonMargin, y: buttonMargin, width: pickerButtonWidth, height: 38))
-        pickerButton.setTitle(NSLocalizedString("Photos", comment: "Select from Photos buttont itle"), for: UIControlState())
-        pickerButton.setImage(UIImage(named: "PhotosIcon"), for: UIControlState())
-        pickerButton.addTarget(self, action: #selector(presentImagePickerTapped(_:)), for: .touchUpInside)
-        pickerButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.footnote)
-        pickerButton.autoresizingMask = [.flexibleTopMargin]
-        pickerButton.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
-        roundifyButton(pickerButton)
-        view.addSubview(pickerButton)
+        if imagePickerAdapter != nil {
+            let pickerButtonWidth: CGFloat = 114
+            pickerButton = UIButton(frame: CGRect(x: view.bounds.width - pickerButtonWidth - buttonMargin, y: buttonMargin, width: pickerButtonWidth, height: 38))
+            pickerButton.setTitle(NSLocalizedString("Photos", comment: "Select from Photos buttont itle"), for: UIControlState())
+            pickerButton.setImage(UIImage(named: "PhotosIcon"), for: UIControlState())
+            pickerButton.addTarget(self, action: #selector(presentImagePickerTapped(_:)), for: .touchUpInside)
+            pickerButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.footnote)
+            pickerButton.autoresizingMask = [.flexibleTopMargin]
+            pickerButton.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+            roundifyButton(pickerButton)
+            view.addSubview(pickerButton)
+        }
 
         previewView.alpha = 0.0
         captureManager.prepare { error in
@@ -318,7 +320,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
             return
         }
 
-        let controller = imagePickerAdapter.viewControllerForImageSelection({ assets in
+        guard let controller = imagePickerAdapter?.viewControllerForImageSelection({ assets in
             if let waitView = self.imagePickerWaitingForImageDataView, assets.count > 0 {
                 waitView.translatesAutoresizingMaskIntoConstraints = false
                 self.view.addSubview(waitView)
@@ -365,7 +367,9 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
             DispatchQueue.main.async {
                 self.dismiss(animated: true, completion: nil)
             }
-        })
+        }) else {
+            return
+        }
 
         present(controller, animated: true, completion: nil)
     }
@@ -530,3 +534,4 @@ extension UIView {
         }
     }
 }
+

--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -31,6 +31,8 @@ public protocol PhotoCaptureViewControllerDelegate: NSObjectProtocol {
 
 open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayoutDelegate {
     open weak var delegate: PhotoCaptureViewControllerDelegate?
+    /// Optional instance confirming to the ImagePickerAdapter-protocol to allow selecting an image from the library. 
+    /// The default implementation will present a UIImagePickerController. Setting this to nil, will remove the library-button. 
     open var imagePickerAdapter: ImagePickerAdapter? = ImagePickerControllerAdapter() {
         didSet {
             updateImagePickerButton()


### PR DESCRIPTION
### What?

`var imagePickerAdapter: ImagePickerAdapter?` can now be nilled in order to disable the image picker; or to make Finjinon a camera-only controller.

![screenshot](https://user-images.githubusercontent.com/28587595/32042328-723a27c4-ba37-11e7-93fd-f9eb0717d0cf.png)

### Why?

There's a desire to use Finjinon as a camera-capture controller alongside a separate and direct entry for picking images from the images library.