### PR TITLE
Fix for pickerButton that ends up behind the previewView in some cases

### DIFF
--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -220,9 +220,10 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
             }
         } else {
             let pickerButtonWidth: CGFloat = 114
+            let buttonRect = CGRect(x: viewFrame.width - pickerButtonWidth - buttonMargin, y: viewFrame.origin.y + buttonMargin, width: pickerButtonWidth, height: 38)
 
             if pickerButton == nil {
-                pickerButton = UIButton(frame: CGRect(x: viewFrame.width - pickerButtonWidth - buttonMargin, y: viewFrame.origin.y + buttonMargin, width: pickerButtonWidth, height: 38))
+                pickerButton = UIButton(frame: buttonRect)
                 pickerButton!.setTitle(NSLocalizedString("Photos", comment: "Select from Photos button title"), for: UIControlState())
                 pickerButton!.setImage(UIImage(named: "PhotosIcon"), for: UIControlState())
                 pickerButton!.addTarget(self, action: #selector(presentImagePickerTapped(_:)), for: .touchUpInside)
@@ -232,8 +233,9 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
                 roundifyButton(pickerButton!)
                 view.addSubview(pickerButton!)
             } else {
-                pickerButton?.frame = CGRect(x: viewFrame.width - pickerButtonWidth - buttonMargin, y: viewFrame.origin.y + buttonMargin, width: pickerButtonWidth, height: 38)
+                pickerButton!.frame = buttonRect
             }
+            view.bringSubview(toFront: pickerButton!)
         }
     }
 


### PR DESCRIPTION
### What?

`view.bringSubview(toFront: pickerButton!)` is ran in `updateImagePickerButton()` to ensure that the the button is always on top (visible), regardless of when then `imagePickerAdapter`'s didSet creates the pickerButton.

### Why?

The pickerButton is hidden behind the previewView if a custom `imagePickerAdapter` is set before `viewDidAppear`.

_Footnote:_
_Setting subviews in viewDidAppear is not a great solution... It's a fix to respect Safe Areas (known after viewDidAppear) for iPhone X in particular. Setting positions constrained to Safe Area would allow for more flexibility with Auto Layout, and thus creating the subViews in viewDidLoad/viewWillAppear would be possible again._