### PR TITLE
Fix iPad bottom margin

### DIFF
--- a/Finjinon/PhotoCaptureViewController.swift
+++ b/Finjinon/PhotoCaptureViewController.swift
@@ -146,7 +146,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         previewView.addGestureRecognizer(tapper)
 
         var collectionViewHeight: CGFloat = min(viewFrame.size.height / 6, 120)
-        let collectionViewBottomMargin: CGFloat = 0 //70
+        let collectionViewBottomMargin: CGFloat = 70
         let cameraButtonHeight: CGFloat = 66
 
         var containerFrame = CGRect(x: viewFrame.origin.x, y: viewFrame.origin.y + viewBounds.height - collectionViewBottomMargin - collectionViewHeight, width: viewBounds.width, height: collectionViewBottomMargin + collectionViewHeight)


### PR DESCRIPTION
### What?

Restore the original value for `collectionViewBottomMargin` to place the collection view above the trigger button. (Affecting iPad only)

<img width="761" alt="skjermbilde 2017-11-08 kl 10 21 07" src="https://user-images.githubusercontent.com/28587595/32541487-23ebc2ba-c470-11e7-8738-ffe324e8f6be.png">


### Why?

The misplacement of the collection view wend unnoticed while implementing changes for iPhone X.