### PR TITLE
Fix: Flashmode crash on iPads

### DIFF
--- a/Sources/PhotoCaptureViewController/CaptureManager.swift
+++ b/Sources/PhotoCaptureViewController/CaptureManager.swift
@@ -130,6 +130,9 @@ class CaptureManager: NSObject {
             self.cameraSettings = self.createCapturePhotoSettingsObject()
 
             guard let cameraSettings = self.cameraSettings else { return }
+            if !self.cameraOutput.supportedFlashModes.contains(cameraSettings.flashMode) {
+                cameraSettings.flashMode = .off
+            }
             self.cameraOutput.capturePhoto(with: cameraSettings, delegate: self)
         }
     }


### PR DESCRIPTION
# Why?
Ref. [this Crashlytics error](https://console.firebase.google.com/u/0/project/fir-ios-finn/crashlytics/app/ios:no.finn.ipad.rubrikk/issues/3c01f3375d0bf48320260f80df5b31b3) that says:

> **Fatal Exception: NSInvalidArgumentException** 
> *** `-[AVCapturePhotoOutput capturePhotoWithSettings:delegate:]` flashMode must be set to a value present in the supportedFlashModes array

This crash only happens on iPads, and we set `flashMode` to a value that isn't supported by some devices.

# What?
- Set `flashMode` to `.off` if the current mode isn't within `cameraOutput.supportedFlashModes`.