### PR TITLE
Remove strong reference cycle in PhotoCaptureViewController

### DIFF
--- a/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
+++ b/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
@@ -76,15 +76,12 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
 
         view.backgroundColor = UIColor.black
 
-        NotificationCenter.default.addObserver(forName: UIDevice.orientationDidChangeNotification, object: nil, queue: nil) { (_) -> Void in
-            switch UIDevice.current.orientation {
-            case .faceDown, .faceUp, .unknown:
-                ()
-            case .landscapeLeft, .landscapeRight, .portrait, .portraitUpsideDown:
-                self.orientation = UIDevice.current.orientation
-                self.updateWidgetsToOrientation()
-            }
-        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleOrientationChange),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
     }
 
     open override func viewDidAppear(_ animated: Bool) {
@@ -106,6 +103,12 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
 
         collectionView.reloadData()
         scrollToLastAddedAssetAnimated(false)
+    }
+
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        NotificationCenter.default.removeObserver(self)
     }
 
     func setupSubviews() {
@@ -352,6 +355,16 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
     }
 
     // MARK: - Actions
+
+    @objc private func handleOrientationChange() {
+        switch UIDevice.current.orientation {
+        case .faceDown, .faceUp, .unknown:
+            ()
+        case .landscapeLeft, .landscapeRight, .portrait, .portraitUpsideDown:
+            self.orientation = UIDevice.current.orientation
+            self.updateWidgetsToOrientation()
+        }
+    }
 
     @objc func flashButtonTapped(_: UIButton) {
         let mode = captureManager.nextAvailableFlashMode() ?? .off

--- a/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
+++ b/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
@@ -358,11 +358,13 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
 
     @objc private func handleOrientationChange() {
         switch UIDevice.current.orientation {
-        case .faceDown, .faceUp, .unknown:
-            ()
         case .landscapeLeft, .landscapeRight, .portrait, .portraitUpsideDown:
             self.orientation = UIDevice.current.orientation
             self.updateWidgetsToOrientation()
+        case .faceDown, .faceUp, .unknown:
+            break
+        @unknown default:
+            break
         }
     }
 
@@ -376,6 +378,8 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
                 self.flashButton.setTitle("finjinon.on".localized(), for: .normal)
             case .auto:
                 self.flashButton.setTitle("finjinon.auto".localized(), for: .normal)
+            @unknown default:
+                break
             }
         }
     }

--- a/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
+++ b/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
@@ -69,6 +69,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
 
     deinit {
         captureManager.stop(nil)
+        NotificationCenter.default.removeObserver(self)
     }
 
     open override func viewDidLoad() {
@@ -103,12 +104,6 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
 
         collectionView.reloadData()
         scrollToLastAddedAssetAnimated(false)
-    }
-
-    open override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-
-        NotificationCenter.default.removeObserver(self)
     }
 
     func setupSubviews() {


### PR DESCRIPTION
# Why

Due to a strong reference cycle in `PhotoCaptureViewController` it's never deallocated. This makes the `AVCaptureSession` in `CaptureManager` persist. The consequence of this, is that the camera indicator introduced in iOS 14 will indicate that the application is using the camera, even after the view controller is closed. 

# What

Identified that the strong reference cycle were in the observer for orientation changes and replaced it with a selector pattern instead. Could have captured the reference cycle in the block, but felt the selector pattern were cleaner and safer. 

# Debugging

The first screenshot shows the reference cycle in `PhotoCaptureViewController` in the memory graph debugger. The second shows that there's no reference to Finjinon after the view controller is closed. 

| Before | After |
| -- | -- |
| <img width="1679" alt="Screenshot 2020-10-16 at 14 39 01" src="https://user-images.githubusercontent.com/3852639/96260294-26429500-0fbf-11eb-93a5-1c657bbc8fe6.png"> | <img width="1680" alt="Screenshot 2020-10-16 at 14 44 22" src="https://user-images.githubusercontent.com/3852639/96260310-29d61c00-0fbf-11eb-9f2d-7c48dcbf3947.png"> |
