### PR TITLE
Flashbutton text width expanded to fit Finnish translations

### DIFF
--- a/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
+++ b/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
@@ -130,7 +130,7 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         focusIndicatorView.alpha = 0.0
         previewView.addSubview(focusIndicatorView)
 
-        flashButton.frame = CGRect(x: viewFrame.origin.x + buttonMargin, y: viewFrame.origin.y + buttonMargin, width: 70, height: 38)
+        flashButton.frame = CGRect(x: viewFrame.origin.x + buttonMargin, y: viewFrame.origin.y + buttonMargin, width: 130, height: 38)
 
         let icon = UIImage(named: "LightningIcon", in: Bundle.finjinon, compatibleWith: nil)
         flashButton.setImage(icon, for: .normal)

--- a/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
+++ b/Sources/PhotoCaptureViewController/PhotoCaptureViewController.swift
@@ -130,7 +130,8 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         focusIndicatorView.alpha = 0.0
         previewView.addSubview(focusIndicatorView)
 
-        flashButton.frame = CGRect(x: viewFrame.origin.x + buttonMargin, y: viewFrame.origin.y + buttonMargin, width: 130, height: 38)
+        var buttonFrame = CGRect(x: viewFrame.origin.x + buttonMargin, y: viewFrame.origin.y + buttonMargin, width: 70, height: 38)
+        flashButton.frame = buttonFrame
 
         let icon = UIImage(named: "LightningIcon", in: Bundle.finjinon, compatibleWith: nil)
         flashButton.setImage(icon, for: .normal)
@@ -140,6 +141,9 @@ open class PhotoCaptureViewController: UIViewController, PhotoCollectionViewLayo
         flashButton.tintColor = UIColor.white
         flashButton.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
         roundifyButton(flashButton, inset: 14)
+        flashButton.sizeToFit()
+        buttonFrame.size.width = max(flashButton.frame.size.width + 35, 70)
+        flashButton.frame = buttonFrame
 
         let tapper = UITapGestureRecognizer(target: self, action: #selector(focusTapGestureRecognized(_:)))
         previewView.addGestureRecognizer(tapper)


### PR DESCRIPTION
FlashButton title is given needed width to display Finnish translation. 
The width is still set as a fixed value, using sizeToFit() would breaks the tap function as this also is re-setting of text width.

| Before | After |
| --- | --- |
|![IMG_1798](https://github.com/finn-no/Finjinon/assets/1043747/c38b51d4-42f9-4355-ac44-7cd1c5c9f5ed) | ![IMG_1799](https://github.com/finn-no/Finjinon/assets/1043747/388fe327-d899-4f31-a7d9-e5ed2f0668c1)![IMG_1797](https://github.com/finn-no/Finjinon/assets/1043747/fe445fbe-996c-405d-aa6d-429eb714d04c)|